### PR TITLE
Added GridFS support with zero API change #4

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -42,6 +42,7 @@
   <!-- Python dependencies  -->
   <exec_depend version_gte="1.0.1">python-pathlib</exec_depend>
   <exec_depend version_gte="3.6.1">python-pymongo</exec_depend>
+  <exec_depend version_gte="3.6.1">python-gridfs</exec_depend>
   <exec_depend version_gte="1.2.6">python-rospkg</exec_depend>
   <exec_depend version_gte="4.19.0">python-tqdm</exec_depend>
   <exec_depend version_gte="3.12">python-yaml</exec_depend>

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -26,7 +26,7 @@ def topic_store_to_mongodb(topic_store_file, scenario_file):
     print("Converting '{}' to MongoDB '{}'".format(topic_store_file.name, client.uri))
 
     storage = TopicStorage.load(topic_store_file)
-    count = len(storage)  # TODO: very slow operation
+    count = 0  # TODO: very slow operation
     with tqdm(total=count) as progress_bar:
         for item in storage:
             try:

--- a/src/topic_store/filesystem.py
+++ b/src/topic_store/filesystem.py
@@ -73,9 +73,9 @@ class TopicStorage(Storage):
     #             # In this case its an index error
     #             raise IndexError("File '{}' does not contain {} elements".format(self.path, item))
     #
-    def __len__(self):
-        print("len(TopicStorage) should not be used as it has to load all files before returning!")
-        count = 0
-        for _ in self:
-            count += 1
-        return count
+    # def __len__(self):
+    #     print("len(TopicStorage) should not be used as it has to load all files before returning!")
+    #     count = 0
+    #     for _ in self:
+    #         count += 1
+    #     return count


### PR DESCRIPTION
Strategy for supporting 16MB documents is that all bson.Binary types (Images) are now chunked by gridfs and stored in the database. Support can be added in the future for more types but this should support most large ROS messages. 

Addressed issue  #4.

Example db document change:
```json
Before:
{
  "image": {
    "height": ...,
    "width": ...,
    "data": Binary(...),
  },
}

After:
{
  "image": {
    "height": ...,
    "width": ...,
    "__grid_fs_data": ObjectID(...), # Use this ID to retrieve the file from grid FS or if loaded through TopicStore API, no changes needed.
  },
}
```