### PR TITLE
ignore errors in slot filling

### DIFF
--- a/src/topic_store/data.py
+++ b/src/topic_store/data.py
@@ -331,7 +331,13 @@ class TopicStore:
                 if hasattr(msg_class, "_connection_header") and "_connection_header" in d:
                     slot_names.append("_connection_header")
                 for s in slot_names:  # or cls = msg_class(**v) after removing ros meta etc
-                    setattr(cls, s, d[s])
+                    try:
+                        setattr(cls, s, d[s])
+                    except KeyError as e:
+                        # Here we accept that if the message type has changed that we cannot
+                        # necessarily fill all slots as we'd like. Maybe a warning should be logged, though
+                        pass
+
             return cls
         elif isinstance(d, dict):
             for k, v in d.items():


### PR DESCRIPTION
that are due to an outdated ROS message definition. This happened to me, because the definition of the `thorvald_base/BatteryData` has changed since we recorded the data :-( 

Best I could think if is to simply pass when this `KeyError` occurs, but you may want to log a warning. Didn't know what logging you'd want for this, @RaymondKirk .

Otherwise, the mongoexport works as expected, though small correction on the query you had in your example. What worked for me, for instance, was this:

```
/scripts/convert.py -i "mongodb://USERNAME:PASSWORD@HOST:PORT/?authSource=ff_rasberry&tls=true&tlsAllowInvalidCertificates=true" -c 2020_riseholme_framos_cameras -q '{"_id":"ObjectId(5f115ee6af915351df739757)"}' -o out.bag
```

So, it needs `ObjectId` to be part of the query.