### PR TITLE
Improvements

### DIFF
--- a/src/topic_store/convert.py
+++ b/src/topic_store/convert.py
@@ -192,8 +192,8 @@ def client_from_uri(uri, collection):
         # DB name will usually be specified as authSource in the URI, if not present use default=topic_store
         db_name = None
         if "authSource" in uri:
-            options = [s.split('=') for s in urlparse(uri).query.split("&") if s]
-            options = {k: v for k, v in options}
+            # get options from URI
+            options = dict([x.split("=") for x in uri.split("?")[1].split("&")])
             if "authSource" in options:
                 db_name = options["authSource"]
         client = MongoStorage(collection=collection, uri=uri, db_name=db_name)

--- a/src/topic_store/convert.py
+++ b/src/topic_store/convert.py
@@ -202,6 +202,14 @@ def client_from_uri(uri, collection):
         raise ValueError("Not a valid URI: {}".format(uri))
 
 
+def private_srv(srv):
+    original_type = type(srv)
+    srv = str(srv)
+    if ":" in srv and "@" in srv:
+        srv = f"mongodb://****:****@" + srv.split("@")[1]
+    return original_type(srv)
+
+
 def _convert_cli():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", help="Input File", type=str, required=True)

--- a/src/topic_store/convert.py
+++ b/src/topic_store/convert.py
@@ -79,12 +79,12 @@ def count_mongodb_items(storage, query=None, estimate=False):
     raise TypeError("Unsupported storage type: {}".format(type(storage)))
 
 
-def get_mongodb_storage(mongodb_client, query=None, projection=None):
+def get_mongodb_storage(mongodb_client, query=None, projection=None, **kwargs):
     if query is None or not isinstance(query, dict):
         storage, count = get_mongo_storage_by_session(mongodb_client, query, skip_on_error=True,
                                                       projection=projection)
     else:
-        storage = mongodb_client.find(query, skip_on_error=True, projection=projection)
+        storage = mongodb_client.find(query, skip_on_error=True, projection=projection, **kwargs)
         count = mongodb_client.count(query, estimate=not bool(query))
     return storage, count
 

--- a/src/topic_store/database.py
+++ b/src/topic_store/database.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+from typing import Iterable, Mapping
 
 import rospkg
 import bson
@@ -102,18 +103,22 @@ class MongoStorage(Storage):
         return MongoStorage(config=scenario.storage["config"], collection=scenario.context)
 
     def __apply_fn_to_nested_dict(self, original_dict, iter_dict=None, fn=None):
+        data_dict = copy(original_dict)
         if iter_dict is None:
-            iter_dict = copy(original_dict)
+            iter_dict = copy(data_dict)
         for k, v in iter_dict.items():
             if isinstance(v, MappingType):
-                original_dict[k] = self.__apply_fn_to_nested_dict(original_dict.get(k, {}), v, fn)
+                try:
+                    data_dict[k] = self.__apply_fn_to_nested_dict(data_dict.get(k, {}), v, fn)
+                except RuntimeError:
+                    pass
             else:
                 fk, fv = k, v
                 if fn is not None:
                     fk, fv = fn(k, v)
-                original_dict[k] = fv
-                original_dict[fk] = original_dict.pop(k)
-        return original_dict
+                data_dict[k] = fv
+                data_dict[fk] = data_dict.pop(k)
+        return data_dict
 
     def __gridfs_ify(self, topic_store):
         """Places all bson.binary.Binary types in the gridfs files/storage system so no limit on 16MB documents"""
@@ -172,26 +177,31 @@ class MongoStorage(Storage):
         # Allow the user to not auto fetch blob data
         skip_fetch_binary = kwargs.pop("skip_fetch_binary", False)
         skip_on_error = kwargs.pop("skip_on_error", False)
+        include_ts_meta = kwargs.pop("include_ts_meta", True)
+        raw_cursor = kwargs.pop("raw_cursor", False)
 
         # If projections exist we must append _ts_meta to it to reconstruct the original object
-        if len(args) >= 2 and isinstance(args[1], dict):
+        if include_ts_meta and len(args) >= 2 and isinstance(args[1], dict):
             if all(x == 1 for x in args[1].values()):
                 args[1]["_ts_meta"] = 1  # Force _ts_meta always if projection is an inclusion rule
             if "_ts_meta" in args[1] and args[1]["_ts_meta"] == 0:  # Don't allow the user to exclude _ts_meta
                 args[1].pop("_ts_meta")
-        if isinstance(kwargs, dict) and isinstance(kwargs.get("projection"), dict):
+        if include_ts_meta and isinstance(kwargs, dict) and isinstance(kwargs.get("projection"), dict):
             if all(x == 1 for x in kwargs["projection"].values()):
                 kwargs["projection"]["_ts_meta"] = 1
             if "_ts_meta" in kwargs["projection"] and kwargs["projection"]["_ts_meta"] == 0:
                 kwargs["projection"].pop("_ts_meta")
 
-        return skip_fetch_binary, skip_on_error, args, kwargs
+        return skip_fetch_binary, skip_on_error, raw_cursor, args, kwargs
 
     def find(self, *args, **kwargs):
         """Returns TopicStoreCursor to all documents in the query"""
-        skip_fetch_binary, skip_on_error, args, kwargs = self.__parse_find_args_kwargs(args, kwargs)
+        skip_fetch_binary, skip_on_error, raw_cursor, args, kwargs = self.__parse_find_args_kwargs(args, kwargs)
 
         find_cursor = self.collection.find(*args, **kwargs)
+
+        if raw_cursor:
+            return find_cursor
 
         return TopicStoreCursor(find_cursor,
                                 apply_fn=None if (skip_fetch_binary or not self._use_grid_fs) else self.__ungridfs_ify,
@@ -199,38 +209,18 @@ class MongoStorage(Storage):
 
     def aggregate(self, *args, **kwargs):
         """Returns TopicStoreCursor to all documents in the query"""
-        skip_fetch_binary, skip_on_error, args, kwargs = self.__parse_find_args_kwargs(args, kwargs)
+        skip_fetch_binary, skip_on_error, raw_cursor, args, kwargs = self.__parse_find_args_kwargs(args, kwargs)
 
         find_cursor = self.collection.aggregate(*args, **kwargs)
+
+        if raw_cursor:
+            return find_cursor
 
         return TopicStoreCursor(find_cursor,
                                 apply_fn=None if (skip_fetch_binary or not self._use_grid_fs) else self.__ungridfs_ify,
                                 skip_on_error=skip_on_error)
 
     __iter__ = find
-
-    def find_one(self, query, *args, **kwargs):
-        """Returns a matched TopicStore document"""
-        # TODO: remove FIND_ONE function in place of generic find function
-        skip_fetch_binary, skip_on_error, args, kwargs = self.__parse_find_args_kwargs(args, kwargs)
-
-        doc = None
-        try:
-            doc = self.collection.find_one(query, *args, **kwargs)
-            if not doc:  # Return if doc not found
-                return doc
-
-            parsed_document = self.reverse_parser(doc)
-            if not skip_fetch_binary and self._use_grid_fs:
-                parsed_document = self.__ungridfs_ify(parsed_document)
-            return TopicStore(parsed_document)
-        except Exception as e:
-            if not skip_on_error:
-                raise
-            print("Skipping document '{}' because '{}'".format(
-                (doc.get('id') + " ") if doc else None, e.message)
-            )
-            return doc
 
     def count(self, query=None, estimate=True):
         """Returns the number of documents in the collection"""
@@ -246,7 +236,7 @@ class MongoStorage(Storage):
 
     def find_by_id(self, id_str, *args, **kwargs):
         """Returns a matched TopicStore document"""
-        return self.find_one({"_id": id_str}, *args, **kwargs)
+        return next(self.find({"_id": id_str}, *args, limit=1, **kwargs))
 
     def find_by_session_id(self, session_id, *args, **kwargs):
         """Returns matched TopicStore documents collected in the same session"""


### PR DESCRIPTION
Addresses some points in #29 

- there are some limitations of ros_bags and db_queries, mostly localhost databases will cache the data for the query cursor so the host RAM will quickly fill and iterables will slow down, you can fix this with database configuration/more optimised queries, I've added a very memory friendly database clone function here for you to see as an example. It requires very little resource to clone an entire db to prove the concept, however the host may still be RAM heavy depending on DB setup.
- count_documents is used in https://github.com/RaymondKirk/topic_store/blob/master/src/topic_store/database.py#L235-L245

Thank you for the suggestions!

